### PR TITLE
Launcher prioritizes PlainApplication over traditional xsbti.AppMain

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
@@ -304,9 +304,9 @@ class Launch private[xsbt] (val bootDirectory: File, val lockBoot: Boolean, val 
       lazy val entryPoint: Class[T] forSome { type T } =
         {
           val c = Class.forName(id.mainClass, true, loader)
-          if (classOf[xsbti.AppMain].isAssignableFrom(c)) c
+          if (ServerApplication.isServerApplication(c)) c
+          else if (classOf[xsbti.AppMain].isAssignableFrom(c)) c
           else if (PlainApplication.isPlainApplication(c)) c
-          else if (ServerApplication.isServerApplication(c)) c
           else sys.error(s"${c} is not an instance of xsbti.AppMain, xsbti.ServerMain nor does it have one of these static methods:\n" +
             " * void main(String[] args)\n * int main(String[] args)\n * xsbti.Exit main(String[] args)\n")
         }
@@ -314,8 +314,8 @@ class Launch private[xsbt] (val bootDirectory: File, val lockBoot: Boolean, val 
       def mainClass: Class[T] forSome { type T <: xsbti.AppMain } = entryPoint.asSubclass(AppMainClass)
       def newMain(): xsbti.AppMain = {
         if (ServerApplication.isServerApplication(entryPoint)) ServerApplication(this)
-        else if (PlainApplication.isPlainApplication(entryPoint)) PlainApplication(entryPoint)
         else if (AppMainClass.isAssignableFrom(entryPoint)) mainClass.newInstance
+        else if (PlainApplication.isPlainApplication(entryPoint)) PlainApplication(entryPoint)
         else throw new IncompatibleClassChangeError(s"Main class ${entryPoint.getName} is not an instance of xsbti.AppMain, xsbti.ServerMain nor does it have a valid `main` method.")
       }
       lazy val components = componentProvider(appHome)

--- a/launcher-implementation/src/test/scala/ScalaProviderTest.scala
+++ b/launcher-implementation/src/test/scala/ScalaProviderTest.scala
@@ -32,6 +32,9 @@ object ScalaProviderTest extends Specification {
       checkLoad(List("test"), "xsbt.boot.test.PlainArgumentTestWithReturn").asInstanceOf[Exit].code must equalTo(0)
       checkLoad(List(), "xsbt.boot.test.PlainArgumentTestWithReturn").asInstanceOf[Exit].code must equalTo(1)
     }
+    "Successfully load an application instead of the plain application" in {
+      checkLoad(List(), "xsbt.boot.test.PriorityTest").asInstanceOf[Exit].code must equalTo(0)
+    }
     "Successfully load an application from local repository and run it with correct sbt version" in {
       checkLoad(List(AppVersion), "xsbt.boot.test.AppVersionTest").asInstanceOf[Exit].code must equalTo(0)
     }

--- a/test-sample/src/main/scala/xsbt/boot/test/Apps.scala
+++ b/test-sample/src/main/scala/xsbt/boot/test/Apps.scala
@@ -30,6 +30,16 @@ class ExtraTest extends xsbti.AppMain {
       new Exit(0)
     }
 }
+class PriorityTest extends xsbti.AppMain {
+  def run(configuration: xsbti.AppConfiguration) =
+    PriorityTest.run(configuration)
+}
+object PriorityTest {
+  def run(configuration: xsbti.AppConfiguration) =
+    new Exit(0)
+  def main(args: Array[String]): Int =
+    throw new MainException("This should not be called")
+}
 object PlainArgumentTestWithReturn {
   def main(args: Array[String]): Int =
     if (args.length == 0) 1


### PR DESCRIPTION
See sbt/sbt#1874
## steps

Define an app that implements both main and `xsbti.AppMain`
## problem

`main` is called.
## expectation

`run` is called.
## notes

sbt/sbt@b0f6f9483918f7e7aeca321e0ff44f745fd5e167 introduced:

``` scala
        def newMain(): xsbti.AppMain = {
          if(PlainApplication.isPlainApplication(entryPoint)) PlainApplication(entryPoint)
          else mainClass.newInstance
        }
```

it's checking `isPlainApplication` first.
