### PR TITLE
`--version` is handled by the launcher

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/Boot.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Boot.scala
@@ -20,7 +20,7 @@ object Boot {
     @annotation.tailrec
     def parse(args: List[String], isLocate: Boolean, remaining: List[String]): LauncherArguments =
       args match {
-        case "--version" :: rest =>
+        case "--launcher-version" :: rest =>
           println("sbt launcher version " + Package.getPackage("xsbt.boot").getImplementationVersion)
           exit(1)
         case "--locate" :: rest => parse(rest, true, remaining)


### PR DESCRIPTION
## steps

```
$ which sbt
/Users/eugene/bin/sbt
$ sbt --version
sbt launcher version 0.13.6
$ which scalaxb
/Users/eugene/bin/scalaxb
$ scalaxb --version 
sbt launcher version 0.13.6
```
## problem

Launcher responding it own version

```
sbt launcher version 0.13.6
```

is not helpful.
## expectation

Older launcher used to delegate `--version` to the underlying application.
I would like `sbt --version` to return the sbt version, and `scalaxb --version` to return the scalaxb version. This becomes more relevant as the sbt launcher stabilizes and is used by both sbt and conscript.
## note

conscript calls `foo --version` when you install `foo` to force download of the necessary JARs.
As such, all conscripted applications are encouraged to implement `--version`.
