### PR TITLE
Change exit code 1 => 0

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/Boot.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Boot.scala
@@ -22,7 +22,7 @@ object Boot {
       args match {
         case "--launcher-version" :: rest =>
           println("sbt launcher version " + Package.getPackage("xsbt.boot").getImplementationVersion)
-          exit(1)
+          exit(0)
         case "--locate" :: rest => parse(rest, true, remaining)
         case next :: rest       => parse(rest, isLocate, next :: remaining)
         case Nil                => new LauncherArguments(remaining.reverse, isLocate)


### PR DESCRIPTION
```
sbt --version
echo $?
```

I expect that 0 is returned as exit code. But actually 1 returns. Why exit code 1 is the returned?

I want to return 0 for the test when it is installed in an automated script.
