### PR TITLE
sbt updates should notify users they may be time consuming

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/Update.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Update.scala
@@ -141,7 +141,7 @@ final class Update(config: UpdateConfiguration) {
             case _                                   => app.name
           }
           val ddesc = addDependency(moduleID, app.groupID, resolvedName, app.getVersion, "default(compile)", u.classifiers)
-          System.out.println("Getting " + app.groupID + " " + resolvedName + " " + app.getVersion + " " + reason + "...")
+          System.out.println("Getting " + app.groupID + " " + resolvedName + " " + app.getVersion + " " + reason + " (this may take some time)...")
           ddesc.getDependencyId
       }
       update(moduleID, target, dep)


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/2774

I am unsure if this is the right way to go about this - it seems like maybe the 'reason' variable may have some further information (i.e. "is this the first time sbt is getting run") but I am unsure where `apply` is called.  Either way, if sbt is being updated, it is likely that the dependencies will also be updated, taking quite some time.

There are a few things I am interested in reviewers commenting on: 
- Firstly, is this the right way to go about this?
- Second, should I have written tests?  It doesn't look like there are many (any?), so I would love to pair up with someone on that since I am new to scala.

Thanks in advance for your help -
James