### PR TITLE
Layered class loading of library and compiler

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
@@ -322,11 +322,18 @@ class Launch private[xsbt] (val bootDirectory: File, val lockBoot: Boolean, val 
     }
   def componentProvider(appHome: File) = new ComponentProvider(appHome, lockBoot)
 
-  def scalaProvider(scalaVersion: String, module: RetrievedModule, parentLoader: ClassLoader, scalaLibDir: File): xsbti.ScalaProvider = new xsbti.ScalaProvider {
+  def scalaProvider(scalaVersion: String, module: RetrievedModule, parentLoader: ClassLoader, scalaLibDir: File): xsbti.ScalaProvider = new xsbti.ExtendedScalaProvider {
     def launcher = Launch.this
     def version = scalaVersion
-    lazy val loader = module.createLoader(parentLoader)
 
+    private object LoaderInit {
+      val (library, other) = module.fullClasspath.partition(_.getName.startsWith("scala-library"))
+      val libraryLoader = new URLClassLoader(toURLs(library), parentLoader)
+      val fullLoader = new URLClassLoader(toURLs(other), libraryLoader)
+    }
+
+    override def loaderLibraryOnly(): ClassLoader = LoaderInit.libraryLoader
+    override def loader(): ClassLoader = LoaderInit.fullLoader
     def compilerJar = new File(scalaLibDir, CompilerModuleName + ".jar")
     def libraryJar = new File(scalaLibDir, LibraryModuleName + ".jar")
     def jars = module.fullClasspath

--- a/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
@@ -328,7 +328,7 @@ class Launch private[xsbt] (val bootDirectory: File, val lockBoot: Boolean, val 
 
     private object LoaderInit {
       val (library, other) = module.fullClasspath.partition(_.getName.startsWith("scala-library"))
-      val libraryLoader = new URLClassLoader(toURLs(library), parentLoader)
+      val libraryLoader = new LibraryClassLoader(toURLs(library), parentLoader, scalaVersion)
       val fullLoader = new URLClassLoader(toURLs(other), libraryLoader)
     }
 

--- a/launcher-implementation/src/main/scala/xsbt/boot/LibraryClassLoader.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/LibraryClassLoader.scala
@@ -1,0 +1,7 @@
+package xsbt.boot
+
+import java.net.{ URL, URLClassLoader }
+
+final class LibraryClassLoader(urls: Array[URL], parent: ClassLoader,
+  val scalaVersion: String) extends URLClassLoader(urls, parent) with xsbti.LibraryClassLoader {
+}

--- a/launcher-implementation/src/test/scala/ScalaProviderTest.scala
+++ b/launcher-implementation/src/test/scala/ScalaProviderTest.scala
@@ -89,7 +89,7 @@ object LaunchTest {
   def testApp(main: String): Application = testApp(main, Array[File]())
   def testApp(main: String, extra: Array[File]): Application = Application("org.scala-sbt", "launch-test", new Explicit(AppVersion), main, Nil, CrossValue.Disabled, extra)
   import Predefined._
-  def testRepositories = List(Local, ScalaToolsReleases, ScalaToolsSnapshots).map(Repository.Predefined(_))
+  def testRepositories = List(Local, MavenCentral, SonatypeOSSSnapshots).map(Repository.Predefined(_))
   def withLauncher[T](f: xsbti.Launcher => T): T =
     withTemporaryDirectory { bootDirectory =>
       f(Launcher(bootDirectory, testRepositories))

--- a/launcher-interface/src/main/java/xsbti/ExtendedScalaProvider.java
+++ b/launcher-interface/src/main/java/xsbti/ExtendedScalaProvider.java
@@ -1,0 +1,7 @@
+package xsbti;
+
+public interface ExtendedScalaProvider extends ScalaProvider
+{
+	/** A ClassLoader that loads the classes from scala-library.jar. It will be the parent of `loader` .*/
+	public ClassLoader loaderLibraryOnly();
+}

--- a/launcher-interface/src/main/java/xsbti/LibraryClassLoader.java
+++ b/launcher-interface/src/main/java/xsbti/LibraryClassLoader.java
@@ -1,0 +1,11 @@
+package xsbti;
+
+import java.io.File;
+
+/**
+ * Marker interface for classloader with just scala-library.
+ */
+public interface LibraryClassLoader
+{
+  public String scalaVersion();
+}


### PR DESCRIPTION
Ref https://github.com/sbt/zinc/pull/505
Ref sbt/sbt#3405
Ref scala/scala-xml#195

This is an on-going effort to fix the `run` classloading problem while keeping the performance optimization.

By constructing layered classloader for library and compiler, we aim to double dip on classloading (and JIT) spin up for both `compile` task and `run`.