### PR TITLE
App name configurable by user

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val testSamples = noPublish(baseProject(file("test-sample"), "Launch Test")
 
 def sbtBuildSettings = Seq(
   bintrayPackage := "launcher",
-  version := "1.0.4-SNAPSHOT",
+  version := "1.1.0-SNAPSHOT",
   publishArtifact in packageDoc := true,
   scalaVersion := "2.10.7",
   publishMavenStyle := true,

--- a/launcher-implementation/src/main/scala/xsbt/boot/Configuration.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Configuration.scala
@@ -76,7 +76,6 @@ object Configuration {
   def DefaultVersionPart = "Default"
   def DefaultBuildProperties = "project/build.properties"
   def SbtVersionProperty = "sbt.version"
-  def SbtAppProperty = "sbt.app"
   val ConfigurationName = "sbt.boot.properties"
   val JarBasePath = "/sbt/"
   def userConfigurationPath = "/" + ConfigurationName

--- a/launcher-implementation/src/main/scala/xsbt/boot/Configuration.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Configuration.scala
@@ -76,6 +76,7 @@ object Configuration {
   def DefaultVersionPart = "Default"
   def DefaultBuildProperties = "project/build.properties"
   def SbtVersionProperty = "sbt.version"
+  def SbtAppProperty = "sbt.app"
   val ConfigurationName = "sbt.boot.properties"
   val JarBasePath = "/sbt/"
   def userConfigurationPath = "/" + ConfigurationName

--- a/launcher-implementation/src/main/scala/xsbt/boot/ConfigurationParser.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/ConfigurationParser.scala
@@ -94,9 +94,12 @@ class ConfigurationParser {
   def processClassifiers(label: String)(value: Option[String]): Value[List[String]] =
     value.map(readValue[List[String]](label)) getOrElse new Explicit(Nil)
 
-  def getVersion(m: LabelMap, label: String, defaultName: String): (Value[String], LabelMap) = process(m, "version", processVersion(label, defaultName))
-  def processVersion(label: String, defaultName: String)(value: Option[String]): Value[String] =
-    value.map(readValue[String](label)).getOrElse(new Implicit(defaultName, None))
+  def getVersion(m: LabelMap, label: String, defaultName: String): (Value[String], LabelMap) =
+    process(m, "version", processLabel(label, defaultName))
+  def getAppName(m: LabelMap, label: String, defaultName: String, defaultValue: String): (Value[String], LabelMap) =
+    process(m, "app", processLabel(label, defaultName, Some(defaultValue)))
+  def processLabel(label: String, defaultName: String, defaultValue: Option[String] = None)(value: Option[String]): Value[String] =
+    value.map(readValue[String](label)).getOrElse(new Implicit(defaultName, defaultValue))
 
   def readValue[T](label: String)(implicit read: String => T): String => Value[T] = value0 =>
     {
@@ -164,15 +167,16 @@ class ConfigurationParser {
     {
       val (org, m1) = id(m, "org", BootConfiguration.SbtOrg)
       val (name, m2) = id(m1, "name", "sbt")
-      val (rev, m3) = getVersion(m2, name + " version", name + ".version")
-      val (main, m4) = id(m3, "class", "xsbt.Main")
-      val (components, m5) = ids(m4, "components", List("default"))
-      val (crossVersioned, m6) = id(m5, "cross-versioned", CrossVersionUtil.binaryString)
-      val (resources, m7) = ids(m6, "resources", Nil)
-      val (classifiers, m8) = getClassifiers(m7, "Application classifiers")
-      check(m8, "label")
+      val (appName, m3) = getAppName(m2, name + " app", name + ".app", name)
+      val (rev, m4) = getVersion(m3, name + " version", name + ".version")
+      val (main, m5) = id(m4, "class", "xsbt.Main")
+      val (components, m6) = ids(m5, "components", List("default"))
+      val (crossVersioned, m7) = id(m6, "cross-versioned", CrossVersionUtil.binaryString)
+      val (resources, m8) = ids(m7, "resources", Nil)
+      val (classifiers, m9) = getClassifiers(m8, "Application classifiers")
+      check(m9, "label")
       val classpathExtra = toArray(toFiles(resources))
-      val app = new Application(org, name, rev, main, components, LaunchCrossVersion(crossVersioned), classpathExtra)
+      val app = new Application(org, appName, rev, main, components, LaunchCrossVersion(crossVersioned), classpathExtra)
       (app, classifiers)
     }
   def getServer(m: LabelMap): (Option[ServerConfiguration]) =

--- a/launcher-implementation/src/main/scala/xsbt/boot/LaunchConfiguration.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/LaunchConfiguration.scala
@@ -76,11 +76,11 @@ object LaunchCrossVersion {
 }
 
 final case class Application(groupID: String, name: Value[String], version: Value[String], main: String, components: List[String], crossVersioned: xsbti.CrossValue, classpathExtra: Array[File]) {
-  def getApp = Value.get(name)
+  def getName = Value.get(name)
   def withName(newName: Value[String]) = Application(groupID, newName, version, main, components, crossVersioned, classpathExtra)
   def getVersion = Value.get(version)
   def withVersion(newVersion: Value[String]) = Application(groupID, name, newVersion, main, components, crossVersioned, classpathExtra)
-  def toID = AppID(groupID, getApp, getVersion, main, toArray(components), crossVersioned, classpathExtra)
+  def toID = AppID(groupID, getName, getVersion, main, toArray(components), crossVersioned, classpathExtra)
   def map(f: File => File) = Application(groupID, name, version, main, components, crossVersioned, classpathExtra.map(f))
 }
 final case class AppID(groupID: String, name: String, version: String, mainClass: String, mainComponents: Array[String], crossVersionedValue: xsbti.CrossValue, classpathExtra: Array[File]) extends xsbti.ApplicationID {

--- a/launcher-implementation/src/main/scala/xsbt/boot/LaunchConfiguration.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/LaunchConfiguration.scala
@@ -20,8 +20,8 @@ final case class LaunchConfiguration(scalaVersion: Value[String], ivyConfigurati
   def withApp(app: Application) = LaunchConfiguration(scalaVersion, ivyConfiguration, app, boot, logging, appProperties, serverConfig)
   def withAppVersion(newAppVersion: String) = LaunchConfiguration(scalaVersion, ivyConfiguration, app.withVersion(new Explicit(newAppVersion)), boot, logging, appProperties, serverConfig)
   // TODO: withExplicit
-  def withVersions(newScalaVersion: String, newAppVersion: String, classifiers0: Classifiers) =
-    LaunchConfiguration(new Explicit(newScalaVersion), ivyConfiguration.copy(classifiers = classifiers0), app.withVersion(new Explicit(newAppVersion)), boot, logging, appProperties, serverConfig)
+  def withNameAndVersions(newScalaVersion: String, newAppVersion: String, newAppName: String, classifiers0: Classifiers) =
+    LaunchConfiguration(new Explicit(newScalaVersion), ivyConfiguration.copy(classifiers = classifiers0), app.withVersion(new Explicit(newAppVersion)).withName(new Explicit(newAppName)), boot, logging, appProperties, serverConfig)
 
   def map(f: File => File) = LaunchConfiguration(scalaVersion, ivyConfiguration.map(f), app.map(f), boot.map(f), logging, appProperties, serverConfig.map(_ map f))
 }
@@ -75,10 +75,12 @@ object LaunchCrossVersion {
     }
 }
 
-final case class Application(groupID: String, name: String, version: Value[String], main: String, components: List[String], crossVersioned: xsbti.CrossValue, classpathExtra: Array[File]) {
+final case class Application(groupID: String, name: Value[String], version: Value[String], main: String, components: List[String], crossVersioned: xsbti.CrossValue, classpathExtra: Array[File]) {
+  def getApp = Value.get(name)
+  def withName(newName: Value[String]) = Application(groupID, newName, version, main, components, crossVersioned, classpathExtra)
   def getVersion = Value.get(version)
   def withVersion(newVersion: Value[String]) = Application(groupID, name, newVersion, main, components, crossVersioned, classpathExtra)
-  def toID = AppID(groupID, name, getVersion, main, toArray(components), crossVersioned, classpathExtra)
+  def toID = AppID(groupID, getApp, getVersion, main, toArray(components), crossVersioned, classpathExtra)
   def map(f: File => File) = Application(groupID, name, version, main, components, crossVersioned, classpathExtra.map(f))
 }
 final case class AppID(groupID: String, name: String, version: String, mainClass: String, mainComponents: Array[String], crossVersionedValue: xsbti.CrossValue, classpathExtra: Array[File]) extends xsbti.ApplicationID {
@@ -89,7 +91,7 @@ object Application {
   def apply(id: xsbti.ApplicationID): Application =
     {
       import id._
-      Application(groupID, name, new Explicit(version), mainClass, mainComponents.toList, safeCrossVersionedValue(id), classpathExtra)
+      Application(groupID, new Explicit(name), new Explicit(version), mainClass, mainComponents.toList, safeCrossVersionedValue(id), classpathExtra)
     }
 
   private def safeCrossVersionedValue(id: xsbti.ApplicationID): xsbti.CrossValue =

--- a/launcher-implementation/src/main/scala/xsbt/boot/ResolveValues.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/ResolveValues.scala
@@ -22,8 +22,9 @@ final class ResolveValues(conf: LaunchConfiguration) {
       import conf._
       val scalaVersion = resolve(conf.scalaVersion)
       val appVersion = resolve(app.version)
+      val appName = resolve(app.name)
       val classifiers = resolveClassifiers(ivyConfiguration.classifiers)
-      withVersions(scalaVersion, appVersion, classifiers)
+      withNameAndVersions(scalaVersion, appVersion, appName, classifiers)
     }
   def resolveClassifiers(classifiers: Classifiers): Classifiers =
     {

--- a/launcher-implementation/src/main/scala/xsbt/boot/Update.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Update.scala
@@ -136,9 +136,9 @@ final class Update(config: UpdateConfiguration) {
         case u: UpdateApp =>
           val app = u.id
           val resolvedName = (app.crossVersioned, scalaVersion) match {
-            case (xsbti.CrossValue.Full, Some(sv))   => app.name + "_" + sv
-            case (xsbti.CrossValue.Binary, Some(sv)) => app.name + "_" + CrossVersionUtil.binaryScalaVersion(sv)
-            case _                                   => app.name
+            case (xsbti.CrossValue.Full, Some(sv))   => app.getApp + "_" + sv
+            case (xsbti.CrossValue.Binary, Some(sv)) => app.getApp + "_" + CrossVersionUtil.binaryScalaVersion(sv)
+            case _                                   => app.getApp
           }
           val ddesc = addDependency(moduleID, app.groupID, resolvedName, app.getVersion, "default(compile)", u.classifiers)
           System.err.println("Getting " + app.groupID + " " + resolvedName + " " + app.getVersion + " " + reason + " (this may take some time)...")

--- a/launcher-implementation/src/main/scala/xsbt/boot/Update.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Update.scala
@@ -136,9 +136,9 @@ final class Update(config: UpdateConfiguration) {
         case u: UpdateApp =>
           val app = u.id
           val resolvedName = (app.crossVersioned, scalaVersion) match {
-            case (xsbti.CrossValue.Full, Some(sv))   => app.getApp + "_" + sv
-            case (xsbti.CrossValue.Binary, Some(sv)) => app.getApp + "_" + CrossVersionUtil.binaryScalaVersion(sv)
-            case _                                   => app.getApp
+            case (xsbti.CrossValue.Full, Some(sv))   => app.getName + "_" + sv
+            case (xsbti.CrossValue.Binary, Some(sv)) => app.getName + "_" + CrossVersionUtil.binaryScalaVersion(sv)
+            case _                                   => app.getName
           }
           val ddesc = addDependency(moduleID, app.groupID, resolvedName, app.getVersion, "default(compile)", u.classifiers)
           System.err.println("Getting " + app.groupID + " " + resolvedName + " " + app.getVersion + " " + reason + " (this may take some time)...")

--- a/launcher-implementation/src/test/scala/ScalaProviderTest.scala
+++ b/launcher-implementation/src/test/scala/ScalaProviderTest.scala
@@ -87,7 +87,7 @@ object ScalaProviderTest extends Specification {
 }
 object LaunchTest {
   def testApp(main: String): Application = testApp(main, Array[File]())
-  def testApp(main: String, extra: Array[File]): Application = Application("org.scala-sbt", "launch-test", new Explicit(AppVersion), main, Nil, CrossValue.Disabled, extra)
+  def testApp(main: String, extra: Array[File]): Application = Application("org.scala-sbt", new Explicit("launch-test"), new Explicit(AppVersion), main, Nil, CrossValue.Disabled, extra)
   import Predefined._
   def testRepositories = List(Local, MavenCentral, SonatypeOSSSnapshots).map(Repository.Predefined(_))
   def withLauncher[T](f: xsbti.Launcher => T): T =

--- a/project/Transform.scala
+++ b/project/Transform.scala
@@ -68,7 +68,7 @@ object Transform {
       Map(
         "org" -> organization.value,
         "sbt.version" -> version.value,
-        "sbt.app" -> name.value,
+        "sbt.name" -> name.value,
         "scala.version" -> scalaVersion.value,
         "repositories" -> repositories(isSnapshot.value).mkString(IO.Newline)
       )

--- a/project/Transform.scala
+++ b/project/Transform.scala
@@ -68,6 +68,7 @@ object Transform {
       Map(
         "org" -> organization.value,
         "sbt.version" -> version.value,
+        "sbt.app" -> name.value,
         "scala.version" -> scalaVersion.value,
         "repositories" -> repositories(isSnapshot.value).mkString(IO.Newline)
       )


### PR DESCRIPTION
This modification is needed to enable users to use:
https://github.com/sbt/sbt/pull/4431

The embedded `sbt.boot.properties` file (haven't found where it's stored) should change from:
```
[scala]
  version: ${sbt.scala.version-auto}

[app]
  org: ${sbt.organization-org.scala-sbt}
  name: sbt

....
```
to:
```
[scala]
  version: ${sbt.scala.version-auto}

[app]
  org: ${sbt.organization-org.scala-sbt}
  name: sbt
  app: ${sbt.app-read(sbt.app)[sbt]}

...
```
in this way everything properly fallback.
This patch is retrocompatible in the sense that the `app` key into the `app` section can be omitted and it behave as expected.

The end result is that an sbt user can declare a `build.properties` file like:
```
sbt.version=1.1.1
sbt.app=sbt-big
```
to choose the artifact name to be used by sbt.

I updated the `minor` version of the launcher since this change the API even if in a back-compatible way.

Names are bad I know, and I'open to better ideas.
cc. @olafurpg @eed3si9n 