### PR TITLE
Add test-interface-1.0.jar to topLoader

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
@@ -220,7 +220,8 @@ class Launch private[xsbt] (val bootDirectory: File, val lockBoot: Boolean, val 
           existing(app, ScalaOrg, explicitScalaVersion, baseDirs(None)) getOrElse retrieve()
 
       case class TestInterfaceLoader(jar: File, parent: ClassLoader) extends URLClassLoader(Array(jar.toURI.toURL), topLoader)
-      retrievedApp.fullClasspath.find(_.toString.endsWith("test-interface-1.0.jar")) foreach { f =>
+      val testInterface = java.util.regex.Pattern.compile("test-interface-[0-9.]+\\.jar")
+      retrievedApp.fullClasspath.find(f => testInterface.matcher(f.getName).find()).foreach { f =>
         scalaProviderClassLoader.set(TestInterfaceLoader(f, initLoader))
       }
       val scalaVersion = getOrError(strictOr(explicitScalaVersion, retrievedApp.detectedScalaVersion), "No Scala version specified or detected")

--- a/launcher-implementation/src/main/scala/xsbt/boot/LibraryClassLoader.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/LibraryClassLoader.scala
@@ -4,4 +4,5 @@ import java.net.{ URL, URLClassLoader }
 
 final class LibraryClassLoader(urls: Array[URL], parent: ClassLoader,
   val scalaVersion: String) extends URLClassLoader(urls, parent) with xsbti.LibraryClassLoader {
+  override def toString: String = s"LibraryClassLoader(jar = ${urls.head}, parent = $parent)"
 }


### PR DESCRIPTION
In sbt, we had problems with the meta build classpath leaking into the
class path of the test task. https://github.com/sbt/sbt/pull/4601
attempted to fix this by constructing a new classloader on sbt startup
in which the test-interface jar was put in a classloader directly below
the boot classloader in the classloading hierarchy. While this was
successful at keeping the sbt classpath out of the test task, it did
significantly increase the meta space overhead of sbt. This manifested
in some projects that ran in sbt 1.2.8 crashing with a metaspace error
in 1.3.0-RC1 (https://github.com/sbt/sbt/issues/4686). This commit takes
the idea of #4601 and applies it at the launcher level. I change
topLoader from a val to a def and, after the project is resolved, if the
test-interface-1.0.jar is in the classpath, we change the topLoader to
have an additional layer that can load just that jar. I can then change
the xMain.run implementation in sbt to check if the topLoader is an
instance of TestInterfaceLoader and, if so, run xMainImpl.run directly.
I verified that the project in #4686 no longer ran out of metaspace
after this change.

I also found that compared to 1.3.0-RC1, the best case time for sbt exit
in a simple project dropped from O(8 seconds) to O(7 seconds).