### PR TITLE
improve the error message when Scala version was not detected

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/Boot.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Boot.scala
@@ -24,7 +24,7 @@ object Boot {
       val sec = Duration(s).toSeconds
       if (sec >= 1) {
         (sec to 1 by -1) foreach { i =>
-          Console.err.println(s"[info] standing by: $i")
+          Console.err.println(s"[info] [launcher] standing by: $i")
           Thread.sleep(1000)
         }
       }
@@ -56,7 +56,7 @@ object Boot {
       Launch(args) map exit
     catch {
       case b: BootException           => errorAndExit(b.toString)
-      case r: xsbti.RetrieveException => errorAndExit("Error: " + r.getMessage)
+      case r: xsbti.RetrieveException => errorAndExit(r.getMessage)
       case r: xsbti.FullReload        => Some(new LauncherArguments(r.arguments.toList, false))
       case e: Throwable =>
         e.printStackTrace
@@ -64,7 +64,9 @@ object Boot {
     }
 
   private def errorAndExit(msg: String): Nothing = {
-    Console.err.println(msg)
+    msg.linesIterator.toList foreach { line =>
+      Console.err.println("[error] [launcher] " + line)
+    }
     exit(1)
   }
 

--- a/launcher-implementation/src/main/scala/xsbt/boot/CheckProxy.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/CheckProxy.scala
@@ -27,7 +27,7 @@ object CheckProxy {
         copyEnv(envPassword, sysPassword)
       } catch {
         case e: MalformedURLException =>
-          Console.err.println(s"[warn] could not parse $envURL setting: ${e.toString}")
+          Console.err.println(s"[warn] [launcher] could not parse $envURL setting: ${e.toString}")
       }
     }
   }

--- a/launcher-implementation/src/main/scala/xsbt/boot/Configuration.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Configuration.scala
@@ -39,7 +39,7 @@ object Configuration {
     }
   def setProperty(head: String): Unit = {
     head.split("=", 2) match {
-      case Array("")         => Console.err.println(s"[warn] invalid system property '$head'")
+      case Array("")         => Console.err.println(s"[warn] [launcher] invalid system property '$head'")
       case Array(key)        => sys.props += key -> ""
       case Array(key, value) => sys.props += key -> value
     }

--- a/launcher-implementation/src/main/scala/xsbt/boot/Find.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Find.scala
@@ -29,7 +29,7 @@ class Find(config: LaunchConfiguration) {
                 case Nil         => Some(current)
                 case head :: Nil => Some(head)
                 case xs =>
-                  Console.err.println("search method is 'only' and multiple ancestor directories match:\n\t" + fromRoot.mkString("\n\t"))
+                  Console.err.println("[error] [launcher] search method is 'only' and multiple ancestor directories match:\n\t" + fromRoot.mkString("\n\t"))
                   System.exit(1)
                   None
               }

--- a/launcher-implementation/src/main/scala/xsbt/boot/JAnsi.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/JAnsi.scala
@@ -18,6 +18,6 @@ object JAnsi {
 				* mitigation code that should not render sbt completely unusable if jansi initialization fails.
 				* [From Mark Harrah, https://github.com/sbt/sbt/pull/633#issuecomment-11957578].
 				*/
-      case ex: Throwable                  => Console.err.println("Jansi found on class path but initialization failed: " + ex)
+      case ex: Throwable                  => Console.err.println("[error] [launcher] Jansi found on class path but initialization failed: " + ex)
     }
 }

--- a/launcher-implementation/src/main/scala/xsbt/boot/Locks.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Locks.scala
@@ -87,7 +87,7 @@ object Locks extends xsbti.GlobalLock {
           {
             val freeLock = try { channel.tryLock } catch { case e: NullPointerException => throw new InternalLockNPE(e) }
             if (freeLock eq null) {
-              Console.err.println("waiting for lock on " + file + " to be available...");
+              Console.err.println("[info] waiting for lock on " + file + " to be available...");
               val lock = try { channel.lock } catch { case e: NullPointerException => throw new InternalLockNPE(e) }
               try { run.call }
               finally { lock.release() }

--- a/launcher-implementation/src/main/scala/xsbt/boot/Pre.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Pre.scala
@@ -25,7 +25,7 @@ object Pre {
   def require(condition: Boolean, msg: => String): Unit = if (!condition) throw new IllegalArgumentException(msg)
   def error(msg: String): Nothing = throw new BootException(prefixError(msg))
   def declined(msg: String): Nothing = throw new BootException(msg)
-  def prefixError(msg: String): String = "error during sbt execution: " + msg
+  def prefixError(msg: String): String = "error during sbt launcher: " + msg
   def toBoolean(s: String) = java.lang.Boolean.parseBoolean(s)
   def toArray[T: ClassManifest](list: List[T]) =
     {


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/4955

When Scala version is set to `auto`, and for some reason the resolution is incomplete (it seems to happen at CI more frequently than normal lately), the launcher will print out the following error message.

## before

```
error during sbt execution: No Scala version specified or detected
```

## after

now it will print this instead:

```
[error] [launcher] error during sbt launcher: sbt/sbt#4955!
[error] [launcher] sbt launcher is unable to detect the Scala version for jline:jline;
[error] [launcher] this likely indicates an incomplete artifact resolution and/or corrupt boot cache (~/.sbt/boot/).
[error] [launcher] the following is the full classpath that was retrieved for jline:jline:
[error] [launcher]  * /tmp/boot/other/jline/jline/2.14.6/jline-2.14.6.jar
```