### PR TITLE
Fix j9 crash by avoiding instantiating WrappedString

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
@@ -232,7 +232,7 @@ class Launch private[xsbt] (val bootDirectory: File, val lockBoot: Boolean, val 
            |sbt launcher is unable to detect the Scala version for ${id.groupID}:${id.name};
            |this likely indicates an incomplete artifact resolution and/or corrupt boot cache (~/.sbt/boot/).
            |the following is the full classpath that was retrieved for ${id.groupID}:${id.name}:
-           |""".stripMargin ++ retrievedApp.fullClasspath.toList.map(x => " * " + x.getAbsolutePath).mkString(System.lineSeparator)
+           |""".stripMargin + retrievedApp.fullClasspath.toList.map(x => " * " + x.getAbsolutePath).mkString(System.lineSeparator)
       )
       val scalaProvider = getScala(scalaVersion, "(for " + id.name + ")")
       val resolvedId = resolveId(retrievedApp.resolvedAppVersion, id)


### PR DESCRIPTION
https://github.com/sbt/sbt/issues/4985 reported that sbt would
immediately crash when using the latest launcher (1.1.2). The crashes
indicated that the problems arose when jit-ing
scala/collection/immutable/WrappedString.apply. We can avoid making a
WrappedString by using `+:` instead of `++`.

Fixes https://github.com/sbt/sbt/issues/4985.