### PR TITLE
Add allowInsecureProtocol flag + redirect support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - unset _JAVA_OPTIONS
 
 script:
-  - sbt -J-XX:ReservedCodeCacheSize=128m -Dsbt.repository.secure=false "$SCRIPTED_TEST"
+  - sbt -J-XX:ReservedCodeCacheSize=128m "$SCRIPTED_TEST"
 
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,11 @@ lazy val launchInterfaceSub =
       generateVersionFile("sbt.launcher.version.properties")(version.value, resourceManaged.value, streams.value, (compile in Compile).value)
     }.taskValue,
     description := "Interfaces for launching projects with the sbt launcher",
-    mimaPreviousArtifacts := Set(organization.value % moduleName.value % "1.0.1")
+    mimaPreviousArtifacts := Set(organization.value % moduleName.value % "1.0.1"),
+    mimaBinaryIssueFilters ++= Seq(
+      exclude[ReversedMissingMethodProblem]("xsbti.MavenRepository.allowInsecureProtocol"),
+      exclude[ReversedMissingMethodProblem]("xsbti.IvyRepository.allowInsecureProtocol")
+    )
   ).settings(Release.settings)
 
 // the launcher.  Retrieves, loads, and runs applications based on a configuration file.

--- a/launcher-implementation/src/main/scala/xsbt/boot/LaunchConfiguration.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/LaunchConfiguration.scala
@@ -109,8 +109,23 @@ object Repository {
   trait Repository extends xsbti.Repository {
     def bootOnly: Boolean
   }
-  final case class Maven(id: String, url: URL, bootOnly: Boolean = false) extends xsbti.MavenRepository with Repository
-  final case class Ivy(id: String, url: URL, ivyPattern: String, artifactPattern: String, mavenCompatible: Boolean, bootOnly: Boolean = false, descriptorOptional: Boolean = false, skipConsistencyCheck: Boolean = false) extends xsbti.IvyRepository with Repository
+  final case class Maven(
+    id: String,
+    url: URL,
+    bootOnly: Boolean = false,
+    allowInsecureProtocol: Boolean = false
+  ) extends xsbti.MavenRepository with Repository
+  final case class Ivy(
+    id: String,
+    url: URL,
+    ivyPattern: String,
+    artifactPattern: String,
+    mavenCompatible: Boolean,
+    bootOnly: Boolean = false,
+    descriptorOptional: Boolean = false,
+    skipConsistencyCheck: Boolean = false,
+    allowInsecureProtocol: Boolean = false
+  ) extends xsbti.IvyRepository with Repository
   final case class Predefined(id: xsbti.Predefined, bootOnly: Boolean = false) extends xsbti.PredefinedRepository with Repository
   object Predefined {
     def apply(s: String): Predefined = new Predefined(xsbti.Predefined.toValue(s), false)

--- a/launcher-implementation/src/test/scala/ConfigurationParserTest.scala
+++ b/launcher-implementation/src/test/scala/ConfigurationParserTest.scala
@@ -38,6 +38,12 @@ object ConfigurationParserTest extends Specification {
 
       repoFileContains(
         """|[repositories]
+           |  id: http://repo1.maven.org, bootOnly, allowInsecureProtocol""".stripMargin,
+        Repository.Maven("id", new URL("http://repo1.maven.org"), true, true)
+      )
+
+      repoFileContains(
+        """|[repositories]
                                             |  id: https://repo1.maven.org, [orgPath]""".stripMargin,
         Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", false, false)
       )
@@ -114,6 +120,11 @@ object ConfigurationParserTest extends Specification {
         Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", true, true)
       )
 
+      repoFileContains(
+        """|[repositories]
+           |  id: http://repo1.maven.org, [orgPath], [artPath], mavenCompatible, bootOnly, allowInsecureProtocol""".stripMargin,
+        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", mavenCompatible = true, bootOnly = true, allowInsecureProtocol = true)
+      )
     }
   }
 

--- a/launcher-interface/src/main/java/xsbti/IvyRepository.java
+++ b/launcher-interface/src/main/java/xsbti/IvyRepository.java
@@ -11,4 +11,5 @@ public interface IvyRepository extends Repository
 	boolean mavenCompatible();
 	boolean skipConsistencyCheck();
 	boolean descriptorOptional();
+	boolean allowInsecureProtocol();
 }

--- a/launcher-interface/src/main/java/xsbti/MavenRepository.java
+++ b/launcher-interface/src/main/java/xsbti/MavenRepository.java
@@ -6,4 +6,5 @@ public interface MavenRepository extends Repository
 {
 	String id();
 	URL url();
+	boolean allowInsecureProtocol();
 }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -12,6 +12,6 @@ object Deps {
   lazy val junit = "junit" % "junit" % "4.11"
 
   // TODO - these should be like the above, just ModuleIDs
-  lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310"
+  lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-839fad1cdc07cf6fc81364d74c323867230432ad"
   lazy val scalaCompiler = Def.setting("org.scala-lang" % "scala-compiler" % scalaVersion.value)
 }


### PR DESCRIPTION
Ref sbt/sbt#4905

```
$ java -jar ~/work/sbt-modules/launcher/target/sbt-launch-1.1.2-SNAPSHOT.jar @/Users/eed3si9n/.conscript/sbt/sbt/scalas/launchconfig
[warn] [launcher] insecure HTTP request is deprecated 'http://repo.scala-sbt.org/scalasbt/maven-releases/'; switch to HTTPS or opt-in as ',allowInsecureProtocol'
[warn] [launcher] insecure HTTP request is deprecated 'http://repo.scala-sbt.org/scalasbt/maven-snapshots/'; switch to HTTPS or opt-in as ',allowInsecureProtocol'
[warn] [launcher] insecure HTTP request is deprecated 'http://repo.typesafe.com/typesafe/ivy-releases/'; switch to HTTPS or opt-in as ',allowInsecureProtocol'
[warn] [launcher] insecure HTTP request is deprecated 'http://repo.scala-sbt.org/scalasbt/ivy-snapshots/'; switch to HTTPS or opt-in as ',allowInsecureProtocol'
```

Ref sbt/sbt#5059
