### PR TITLE
Add jline and jansi jars to top classloader classpath

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Deps._
 import Util._
 import com.typesafe.tools.mima.core._, ProblemFilters._
 
-version in ThisBuild := "1.1.2-SNAPSHOT"
+version in ThisBuild := "1.1.5-SNAPSHOT"
 
 // the launcher is published with metadata so that the scripted plugin can pull it in
 // being proguarded, it shouldn't ever be on a classpath with other jars, however

--- a/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
@@ -114,6 +114,7 @@ object Launch {
         JAnsi.uninstall(launcher.topLoader)
       }
     }
+  @tailrec
   final def launch(run: RunConfiguration => xsbti.MainResult)(config: RunConfiguration): Option[Int] =
     {
       run(config) match {


### PR DESCRIPTION
For sbt to work correctly, it needs the top loader to contain the jansi, test interface and forked jline jars. The rest of the classpath must be available in a classloader with this top loader as its parent. We can do this at the launcher level so that sbt main does not need to construct such a hierarchy of classloaders itself and can just use the classloader that was passed in by the launcher. sbt main can use the getEarlyJars method to determine if the top loader is compatible with what it expects. This is more scalable than the previous approach which was based on the classloader class name.