### PR TITLE
Do not create jansi classloader in windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_install:
   - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.10.1/install.sh | bash && . ~/.jabba/jabba.sh
 
 install:
-  - curl -L --fail https://piccolo.link/sbt-0.13.17.tgz > sbt-0.13.17.tgz
-  - tar zxf ./sbt-0.13.17.tgz -C $HOME/
+  - curl -L --fail https://github.com/sbt/sbt/releases/download/v0.13.18/sbt-0.13.18.tgz > sbt-0.13.18.tgz
+  - tar zxf ./sbt-0.13.18.tgz -C $HOME/
   - export PATH="$HOME/sbt/bin:$PATH"
   - export SBT_OPTS="-Xms2048M -Xmx2048M -Xss2M -XX:MaxPermSize=512M"
   - sbt about


### PR DESCRIPTION
I am not sure what the historical reasons for the jansi classloader
were, but they cause problems when using the latest jansi with jline 2.
Windows console input works fine in sbt 1.4.x without the jansi loader,
as does the 2.12.12 scala console.