### PR TITLE
Override Scala version for sbt 1.4.x

### DIFF
--- a/ci-test/app2/sbt.1.4.0.boot.properties
+++ b/ci-test/app2/sbt.1.4.0.boot.properties
@@ -12,8 +12,6 @@
 
 [repositories]
   local
-  local-preloaded-ivy: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
-  local-preloaded: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
   maven-central
   sbt-maven-releases: https://repo.scala-sbt.org/scalasbt/maven-releases/, bootOnly
   sbt-maven-snapshots: https://repo.scala-sbt.org/scalasbt/maven-snapshots/, bootOnly

--- a/ci-test/app2/sbt.1.4.0.boot.properties
+++ b/ci-test/app2/sbt.1.4.0.boot.properties
@@ -1,0 +1,31 @@
+[scala]
+  version: ${sbt.scala.version-auto}
+
+[app]
+  org: ${sbt.organization-org.scala-sbt}
+  name: sbt
+  version: ${sbt.version-read(sbt.version)[1.4.0]}
+  class: ${sbt.main.class-sbt.xMain}
+  components: xsbti,extra
+  cross-versioned: ${sbt.cross.versioned-false}
+  resources: ${sbt.extraClasspath-}
+
+[repositories]
+  local
+  local-preloaded-ivy: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  local-preloaded: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
+  maven-central
+  sbt-maven-releases: https://repo.scala-sbt.org/scalasbt/maven-releases/, bootOnly
+  sbt-maven-snapshots: https://repo.scala-sbt.org/scalasbt/maven-snapshots/, bootOnly
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  sbt-ivy-snapshots: https://repo.scala-sbt.org/scalasbt/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+
+[boot]
+  directory: /tmp/boot0/
+  lock: ${sbt.boot.lock-true}
+
+[ivy]
+  ivy-home: ${sbt.ivy.home-${user.home}/.ivy2/}
+  checksums: ${sbt.checksums-sha1,md5}
+  override-build-repos: ${sbt.override.build.repos-false}
+  repository-config: ${sbt.repository.config-${sbt.global.base-${user.home}/.sbt}/repositories}

--- a/ci-test/test.sh
+++ b/ci-test/test.sh
@@ -6,7 +6,10 @@ pushd ci-test/app0
 COURSIER_CACHE=/tmp/cache/ java -jar $LAUNCHER @sbt.1.3.13.boot.properties exit
 popd
 
-#!/bin/bash -e
 pushd ci-test/app1
 COURSIER_CACHE=/tmp/cache/ java -jar $LAUNCHER @sbt.0.13.18.boot.properties exit
+popd
+
+pushd ci-test/app2
+COURSIER_CACHE=/tmp/cache/ java -jar $LAUNCHER @sbt.1.4.0.boot.properties exit
 popd

--- a/launcher-implementation/src/main/scala/xsbt/boot/CoursierUpdate.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/CoursierUpdate.scala
@@ -7,6 +7,7 @@ import coursier.core.{ Publication, Repository }
 import coursier.credentials.DirectCredentials
 import coursier.ivy.IvyRepository
 import coursier.maven.MavenRepository
+import coursier.params.ResolutionParams
 import java.io.{ File, FileWriter, PrintWriter }
 import java.nio.file.{ Files, StandardCopyOption, Paths }
 import java.util.Properties
@@ -108,10 +109,19 @@ class CousierUpdate(config: UpdateConfiguration) {
       deps: List[Dependency]
   ): UpdateResult = {
     val repos = config.repositories.map(toCoursierRepository)
+    val params = scalaVersion match {
+      case Some(sv) if sv != "auto" =>
+        ResolutionParams()
+          .withScalaVersion(sv)
+          .withForceScalaVersion(true)
+      case _ =>
+        ResolutionParams()
+    }
     val r: Resolution = Resolve()
       .withCache(coursierCache)
       .addDependencies(deps: _*)
       .withRepositories(repos)
+      .withResolutionParams(params)
       .run()
     val actualScalaVersion =
       (r.dependencySet.set collect {
@@ -143,6 +153,7 @@ class CousierUpdate(config: UpdateConfiguration) {
       .withCache(coursierCache)
       .addDependencies(deps: _*)
       .withRepositories(repos)
+      .withResolutionParams(params)
       .run()
     downloadedJars foreach { downloaded =>
       val t =

--- a/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
@@ -306,9 +306,20 @@ class Launch private[xsbt] (
 
   @tailrec private[this] final def getAppProvider0(
       id: xsbti.ApplicationID,
-      explicitScalaVersion: Option[String],
+      explicitScalaVersion0: Option[String],
       forceAppUpdate: Boolean
   ): xsbti.AppProvider = {
+    val explicitScalaVersion = explicitScalaVersion0 match {
+      case Some(sv) => Some(sv)
+      case _        =>
+        // https://github.com/sbt/sbt/issues/6587
+        // set the Scala version of sbt 1.4.x series to 2.12.12 explicitly
+        // since util-interface depends on Scala 2.13 by mistake
+        // https://github.com/sbt/sbt/blob/v1.4.0/project/Dependencies.scala
+        if (id.groupID() == "org.scala-sbt" &&
+            id.name() == "sbt" && id.version().startsWith("1.4.")) Some("2.12.12")
+        else None
+    }
     val app = appModule(id, explicitScalaVersion, true, "app")
 
     /** Replace the version of an ApplicationID with the given one, if set. */


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6587

Problem
-------
During sbt 1.4.x series util-interface incorrectly depended on
scala-library. Specifically for util-interface 1.4.0, 1.4.1, and 1.4.2,
this was Scala 2.13. Ivy seemed to be ok with this, but Coursier evicts
Scala 2.12 and resolves to 2.13, which creating a confusing
`java.lang.NoClassDefFoundError: scala/Serializable` error.

Solution
--------
Explicitly override Scala version for sbt 1.4.x to Scala 2.12.12.