### PR TITLE
Add support for auto detecting Scala 3 apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,20 +18,15 @@ jobs:
       JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup
-      uses: olafurpg/setup-scala@v10
+      uses: actions/checkout@v3
+    - name: Setup JDK
+      uses: actions/setup-java@v3
       with:
-        java-version: "adopt@1.${{ matrix.java }}"
-    - name: Coursier cache
-      uses: coursier/cache-action@v6
+        distribution: temurin
+        java-version: "${{ matrix.java }}"
+        cache: sbt
     - name: Build and test
       run: |
         sbt -v "mimaReportBinaryIssues; scalafmtCheckAll; shadedPackageBin; test;"
         ci-test/test.sh
-        rm -rf "$HOME/.ivy2/local" || true
-        find $HOME/Library/Caches/Coursier/v1        -name "ivydata-*.properties" -delete || true
-        find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
-        find $HOME/.cache/coursier/v1                -name "ivydata-*.properties" -delete || true
-        find $HOME/.sbt                              -name "*.lock"               -delete || true
       shell: bash

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 ThisBuild / dynverSonatypeSnapshots := true
 ThisBuild / version := {
   val orig = (ThisBuild / version).value
-  if (orig.endsWith("-SNAPSHOT")) "1.2.0-SNAPSHOT"
+  if (orig.endsWith("-SNAPSHOT")) "1.4.0-SNAPSHOT"
   else orig
 }
 ThisBuild / description := "Standalone launcher for maven/ivy deployed projects"

--- a/ci-test/test.sh
+++ b/ci-test/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-LAUNCHER="../../launcher-implementation/target/proguard/launcher-implementation-1.2.0-SNAPSHOT-shading.jar"
+LAUNCHER="../../launcher-implementation/target/proguard/launcher-implementation-1.4.0-SNAPSHOT-shading.jar"
 
 pushd ci-test/app0
 COURSIER_CACHE=/tmp/cache/ java -jar $LAUNCHER @sbt.1.3.13.boot.properties exit

--- a/launcher-implementation/src/main/scala/xsbt/boot/BootConfiguration.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/BootConfiguration.scala
@@ -16,7 +16,9 @@ private[boot] object BootConfiguration {
   // these are the Scala module identifiers to resolve/retrieve
   val ScalaOrg = "org.scala-lang"
   val CompilerModuleName = "scala-compiler"
+  val Compiler3ModuleName = "scala3-compiler_3"
   val LibraryModuleName = "scala-library"
+  val Library3ModuleName = "scala3-library_3"
 
   val JUnitName = "junit"
   val JAnsiVersion = "1.18"
@@ -56,7 +58,8 @@ private[boot] object BootConfiguration {
    * The loader will check that these classes can be loaded and will assume that their presence indicates
    * the Scala compiler and library have been downloaded.
    */
-  val TestLoadScalaClasses = "scala.Option" :: "scala.tools.nsc.Global" :: Nil
+  val TestLoadScala2Classes = "scala.Option" :: "scala.tools.nsc.Global" :: Nil
+  val TestLoadScala3Classes = "scala.Option" :: "dotty.tools.dotc.Driver" :: Nil
 
   val ScalaHomeProperty = "scala.home"
   val UpdateLogName = "update.log"

--- a/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
@@ -195,7 +195,8 @@ import BootConfiguration.{
   baseDirectoryName,
   extractScalaVersion,
   ScalaDirectoryName,
-  TestLoadScalaClasses,
+  TestLoadScala2Classes,
+  TestLoadScala3Classes,
   ScalaOrg
 }
 class Launch private[xsbt] (
@@ -409,9 +410,12 @@ class Launch private[xsbt] (
     val scalaM = scalaModule(scalaOrg, scalaVersion)
     val (scalaHome, lib) = scalaDirs(scalaM, scalaOrg, scalaVersion)
     val baseDirs = lib :: Nil
+    def testLoadScalaClasses =
+      if (scalaVersion.startsWith("2.")) TestLoadScala2Classes
+      else TestLoadScala3Classes
     def provider(retrieved: RetrievedModule): xsbti.ScalaProvider = {
       val p = scalaProvider(scalaVersion, retrieved, classLoader, lib)
-      checkLoader(p.loader, retrieved.definition, TestLoadScalaClasses, p)
+      checkLoader(p.loader, retrieved.definition, testLoadScalaClasses, p)
     }
     existing(scalaM, scalaOrg, Some(scalaVersion), _ => baseDirs) flatMap { mod =>
       try Some(provider(mod))

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -10,6 +10,6 @@ object Deps {
 
   // TODO - these should be like the above, just ModuleIDs
   lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-839fad1cdc07cf6fc81364d74c323867230432ad"
-  lazy val coursier = "io.get-coursier" %% "coursier" % "2.0.13"
+  lazy val coursier = "io.get-coursier" %% "coursier" % "2.0.16"
   lazy val scalaCompiler = Def.setting("org.scala-lang" % "scala-compiler" % scalaVersion.value)
 }


### PR DESCRIPTION
Problem
-------
Launcher has the ability to auto-detect the Scala version from the dependency graph, and then subsequently use the Scala version knowledge to set up different directories for JAR retrieval etc. Currently the logic is hard-coded for scala-library.jar etc, and it needs some adjustments to work with Scala 3.

Solution
--------
Implement auto detection of Scala 3 apps.