### PR TITLE
Skip Zinc interfaces

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/CoursierUpdate.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/CoursierUpdate.scala
@@ -216,8 +216,17 @@ class CousierUpdate(config: UpdateConfiguration) {
           }
           new File(retrieveDir, name)
         }
-      Files.copy(downloaded.toPath, t.toPath, StandardCopyOption.REPLACE_EXISTING)
-      ()
+      val isSkip =
+        isScala && (downloaded.getName match {
+          case n if n.startsWith("compiler-interface") => true
+          case n if n.startsWith("util-interface")     => true
+          case _                                       => false
+        })
+      if (isSkip) ()
+      else {
+        Files.copy(downloaded.toPath, t.toPath, StandardCopyOption.REPLACE_EXISTING)
+        ()
+      }
     }
     new UpdateResult(true, actualScalaVersion, depVersion)
   }

--- a/launcher-implementation/src/test/scala/ScalaProviderTest.scala
+++ b/launcher-implementation/src/test/scala/ScalaProviderTest.scala
@@ -7,18 +7,6 @@ import LaunchTest._
 import sbt.io.IO.{ createDirectory, touch, withTemporaryDirectory }
 
 object ScalaProviderTest extends verify.BasicTestSuite {
-  test("Launch should provide ClassLoader for Scala 2.8.2") {
-    checkScalaLoader("2.8.2")
-  }
-
-  test("Launch should provide ClassLoader for Scala 2.9.0") {
-    checkScalaLoader("2.9.0")
-  }
-
-  test("Launch should provide ClassLoader for Scala 2.9.2") {
-    checkScalaLoader("2.9.2")
-  }
-
   test("Launch should provide ClassLoader for Scala 2.10.7") {
     checkScalaLoader("2.10.7")
   }
@@ -26,6 +14,19 @@ object ScalaProviderTest extends verify.BasicTestSuite {
   test("Launch should provide ClassLoader for Scala 2.11.12") {
     checkScalaLoader("2.11.12")
   }
+
+  test("Launch should provide ClassLoader for Scala 2.12.17") {
+    checkScalaLoader("2.12.17")
+  }
+
+  test("Launch should provide ClassLoader for Scala 2.13.9") {
+    checkScalaLoader("2.13.9")
+  }
+
+  // Scala version detection picks up 2.13
+  // test("Launch should provide ClassLoader for Scala 3.2.0") {
+  //   checkScalaLoader("3.2.0")
+  // }
 
   test(
     "Launch should successfully load an application from local repository and run it with correct arguments"
@@ -146,7 +147,8 @@ object LaunchTest {
   val finalStyle = Set("2.9.1", "2.9.0-1", "2.9.0", "2.8.2", "2.8.1", "2.8.0")
   def unmapScalaVersion(versionNumber: String) = versionNumber.stripSuffix(".final")
   def mapScalaVersion(versionNumber: String) =
-    if (finalStyle(versionNumber)) versionNumber + ".final" else versionNumber
+    if (finalStyle(versionNumber)) versionNumber + ".final"
+    else versionNumber
 
   def getScalaVersion: String = getScalaVersion(getClass.getClassLoader)
   def getScalaVersion(loader: ClassLoader): String =


### PR DESCRIPTION
Problem
-------
Scala 3 compiler depends on Zinc interfaces
(util-interface and compiler-interface).
This collides when sbt classloads Zinc.

Solution
--------
Skip Zinc interfaces during the retrieval,
so the latest ones gets used.