### PR TITLE
bootOnlyZero

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
@@ -233,8 +233,14 @@ class Launch private[xsbt] (
 
   def globalLock: xsbti.GlobalLock = Locks
   def ivyHome = orNull(ivyOptions.ivyHome)
-  def ivyRepositories = (repositories: List[xsbti.Repository]).toArray
-  def appRepositories = ((repositories filterNot (_.bootOnly)): List[xsbti.Repository]).toArray
+  def ivyRepositories =
+    ((repositories
+      .filterNot(_.bootOnlyZero)): List[xsbti.Repository]).toArray
+  def allRepositories = (repositories: List[xsbti.Repository]).toArray
+  def appRepositories =
+    ((repositories
+      .filterNot(_.bootOnly)
+      .filterNot(_.bootOnlyZero)): List[xsbti.Repository]).toArray
   def isOverrideRepositories: Boolean = ivyOptions.isOverrideRepositories
   def checksums = checksumsList.toArray[String]
 

--- a/launcher-implementation/src/main/scala/xsbt/boot/LaunchConfiguration.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/LaunchConfiguration.scala
@@ -211,11 +211,13 @@ object Application {
 object Repository {
   trait Repository extends xsbti.Repository {
     def bootOnly: Boolean
+    def bootOnlyZero: Boolean
   }
   final case class Maven(
       id: String,
       url: URL,
       bootOnly: Boolean = false,
+      bootOnlyZero: Boolean = false,
       allowInsecureProtocol: Boolean = false
   ) extends xsbti.MavenRepository
       with Repository
@@ -226,13 +228,17 @@ object Repository {
       artifactPattern: String,
       mavenCompatible: Boolean,
       bootOnly: Boolean = false,
+      bootOnlyZero: Boolean = false,
       descriptorOptional: Boolean = false,
       skipConsistencyCheck: Boolean = false,
       allowInsecureProtocol: Boolean = false
   ) extends xsbti.IvyRepository
       with Repository
-  final case class Predefined(id: xsbti.Predefined, bootOnly: Boolean = false)
-      extends xsbti.PredefinedRepository
+  final case class Predefined(
+      id: xsbti.Predefined,
+      bootOnly: Boolean = false,
+      bootOnlyZero: Boolean = false
+  ) extends xsbti.PredefinedRepository
       with Repository
   object Predefined {
     def apply(s: String): Predefined = new Predefined(xsbti.Predefined.toValue(s), false)

--- a/launcher-implementation/src/main/scala/xsbt/boot/ModuleDefinition.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/ModuleDefinition.scala
@@ -14,7 +14,11 @@ final class ModuleDefinition(
   def retrieveCorrupt(missing: Iterable[String]): Nothing =
     fail(": missing " + missing.mkString(", "))
   private def fail(extra: String) =
-    throw new xsbti.RetrieveException(versionString, "could not retrieve " + failLabel + extra)
+    throw new xsbti.RetrieveException(
+      versionString,
+      "could not retrieve " + failLabel + extra
+        + " " + configuration.repositories.mkString(", ")
+    )
   private def versionString: String = target match {
     case _: UpdateScala => configuration.getScalaVersion;
     case a: UpdateApp   => Value.get(a.id.version)

--- a/launcher-implementation/src/test/scala/ConfigurationParserTest.scala
+++ b/launcher-implementation/src/test/scala/ConfigurationParserTest.scala
@@ -31,47 +31,92 @@ object ConfigurationParserTest extends verify.BasicTestSuite {
     repoFileContains(
       """|[repositories]
          |  id: http://repo1.maven.org, bootOnly, allowInsecureProtocol""".stripMargin,
-      Repository.Maven("id", new URL("http://repo1.maven.org"), true, true)
+      Repository.Maven("id", new URL("http://repo1.maven.org"), true, false, true)
     )
 
     repoFileContains(
       """|[repositories]
                                           |  id: https://repo1.maven.org, [orgPath]""".stripMargin,
       Repository
-        .Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", false, false)
+        .Ivy(
+          "id",
+          new URL("https://repo1.maven.org"),
+          "[orgPath]",
+          "[orgPath]",
+          false,
+          false,
+          false
+        )
     )
 
     repoFileContains(
       """|[repositories]
                                           |  id: https://repo1.maven.org, [orgPath], mavenCompatible""".stripMargin,
       Repository
-        .Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", true, false)
+        .Ivy(
+          "id",
+          new URL("https://repo1.maven.org"),
+          "[orgPath]",
+          "[orgPath]",
+          mavenCompatible = true,
+          false,
+          false
+        )
     )
 
     repoFileContains(
       """|[repositories]
                                           |  id: https://repo1.maven.org, [orgPath], mavenCompatible, bootOnly""".stripMargin,
-      Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", true, true)
+      Repository
+        .Ivy(
+          "id",
+          new URL("https://repo1.maven.org"),
+          "[orgPath]",
+          "[orgPath]",
+          mavenCompatible = true,
+          bootOnly = true,
+        )
     )
 
     repoFileContains(
       """|[repositories]
                                           |  id: https://repo1.maven.org, [orgPath], bootOnly, mavenCompatible""".stripMargin,
-      Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", true, true)
+      Repository
+        .Ivy(
+          "id",
+          new URL("https://repo1.maven.org"),
+          "[orgPath]",
+          "[orgPath]",
+          mavenCompatible = true,
+          bootOnly = true,
+        )
     )
 
     repoFileContains(
       """|[repositories]
                                           |  id: https://repo1.maven.org, [orgPath], bootOnly""".stripMargin,
       Repository
-        .Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", false, true)
+        .Ivy(
+          "id",
+          new URL("https://repo1.maven.org"),
+          "[orgPath]",
+          "[orgPath]",
+          mavenCompatible = false,
+          bootOnly = true,
+        )
     )
 
     repoFileContains(
       """|[repositories]
                                           |  id: https://repo1.maven.org, [orgPath], [artPath]""".stripMargin,
       Repository
-        .Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", false, false)
+        .Ivy(
+          "id",
+          new URL("https://repo1.maven.org"),
+          "[orgPath]",
+          "[artPath]",
+          mavenCompatible = false,
+        )
     )
 
     repoFileContains(
@@ -82,10 +127,8 @@ object ConfigurationParserTest extends verify.BasicTestSuite {
         new URL("https://repo1.maven.org"),
         "[orgPath]",
         "[artPath]",
-        false,
-        false,
-        true,
-        false
+        mavenCompatible = false,
+        descriptorOptional = true,
       )
     )
 
@@ -97,10 +140,9 @@ object ConfigurationParserTest extends verify.BasicTestSuite {
         new URL("https://repo1.maven.org"),
         "[orgPath]",
         "[artPath]",
-        false,
-        false,
-        true,
-        true
+        mavenCompatible = false,
+        descriptorOptional = true,
+        skipConsistencyCheck = true,
       )
     )
 
@@ -112,10 +154,9 @@ object ConfigurationParserTest extends verify.BasicTestSuite {
         new URL("https://repo1.maven.org"),
         "[orgPath]",
         "[artPath]",
-        false,
-        false,
-        true,
-        true
+        mavenCompatible = false,
+        descriptorOptional = true,
+        skipConsistencyCheck = true,
       )
     )
 
@@ -127,10 +168,10 @@ object ConfigurationParserTest extends verify.BasicTestSuite {
         new URL("https://repo1.maven.org"),
         "[orgPath]",
         "[artPath]",
-        true,
-        true,
-        true,
-        true
+        mavenCompatible = true,
+        bootOnly = true,
+        descriptorOptional = true,
+        skipConsistencyCheck = true,
       )
     )
 
@@ -138,19 +179,53 @@ object ConfigurationParserTest extends verify.BasicTestSuite {
       """|[repositories]
                                           |  id: https://repo1.maven.org, [orgPath], [artPath], bootOnly""".stripMargin,
       Repository
-        .Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", false, true)
+        .Ivy(
+          "id",
+          new URL("https://repo1.maven.org"),
+          "[orgPath]",
+          "[artPath]",
+          mavenCompatible = false,
+          bootOnly = true,
+        )
     )
 
     repoFileContains(
       """|[repositories]
                                           |  id: https://repo1.maven.org, [orgPath], [artPath], bootOnly, mavenCompatible""".stripMargin,
-      Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", true, true)
+      Repository.Ivy(
+        "id",
+        new URL("https://repo1.maven.org"),
+        "[orgPath]",
+        "[artPath]",
+        mavenCompatible = true,
+        bootOnly = true,
+      )
     )
 
     repoFileContains(
       """|[repositories]
                                           |  id: https://repo1.maven.org, [orgPath], [artPath], mavenCompatible, bootOnly""".stripMargin,
-      Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", true, true)
+      Repository.Ivy(
+        "id",
+        new URL("https://repo1.maven.org"),
+        "[orgPath]",
+        "[artPath]",
+        mavenCompatible = true,
+        bootOnly = true,
+      )
+    )
+
+    repoFileContains(
+      """|[repositories]
+                                          |  id: https://repo1.maven.org, [orgPath], [artPath], mavenCompatible, bootOnlyZero""".stripMargin,
+      Repository.Ivy(
+        "id",
+        new URL("https://repo1.maven.org"),
+        "[orgPath]",
+        "[artPath]",
+        mavenCompatible = true,
+        bootOnlyZero = true,
+      )
     )
 
     repoFileContains(


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/7484

This adds support for a new directive called `bootOnlyZero`, which will be enabled only for sbt 0.x versions.
The intent is mark eventually mark repo.scala-sbt.org etc so it will be used only for sbt 0.13 support.