### PR TITLE
Fix sbt 0.13 support

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/CoursierUpdate.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/CoursierUpdate.scala
@@ -204,6 +204,12 @@ class CousierUpdate(config: UpdateConfiguration):
     val depVersion: Option[String] = target match
       case _: UpdateScala => scalaVersion
       case u: UpdateApp   => Some(Value.get(u.id.version))
+    val isSbt = target match
+      case _: UpdateScala => false
+      case u: UpdateApp   => Some(Value.get(u.id.name)) == Some("sbt")
+    val isZeroDot = depVersion match
+      case Some(v) => v.startsWith("0.")
+      case _       => false
     if !retrieveDir.exists then Files.createDirectories(retrieveDir.toPath)
     val downloadedJars = Fetch()
       .withCache(coursierCache)
@@ -220,6 +226,10 @@ class CousierUpdate(config: UpdateConfiguration):
             case n if n.startsWith("scala-reflect")  => "scala-reflect.jar"
             case n                                   => n
           new File(retrieveDir, name)
+        else if isSbt && downloaded.getName == "interface.jar" && isZeroDot then
+          val componentDir = new File(retrieveDir, "xsbti")
+          Files.createDirectories(componentDir.toPath)
+          new File(componentDir, downloaded.getName)
         else
           val name = downloaded.getName match
             // https://github.com/sbt/sbt/issues/6432


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/8278

## Test

```bash
$ java -jar sbt-launch.jar -Dsbt.ivy.home=/tmp/ivy
[info] [launcher] getting org.scala-sbt sbt 0.13.18  (this may take some time)...
[info] Loading project definition from /private/tmp/test-sbt0.13/project
[info] Set current project to test-sbt0-13 (in build file:/private/tmp/test-sbt0.13/)
test-sbt0-13> compile
[info] Compiling 1 Scala source to /private/tmp/test-sbt0.13/target/scala-2.10/classes...
[info] 'compiler-interface' not yet compiled for Scala 2.10.7. Compiling...
[info]   Compilation completed in 2.648 s
[success] Total time: 4 s
```
