### PR TITLE
Manually construct the string `"org.fusesource.jansi"` instead of hav…

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/JAnsi.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/JAnsi.scala
@@ -5,7 +5,7 @@
 
 package xsbt.boot
 
-import Pre.*
+import xsbt.boot.Pre.*
 
 object JAnsi:
   def uninstall(loader: ClassLoader): Unit = callJAnsi("systemUninstall", loader)
@@ -15,7 +15,8 @@ object JAnsi:
     if isWindows && !isCygwin then callJAnsiMethod(methodName, loader)
   private def callJAnsiMethod(methodName: String, loader: ClassLoader): Unit =
     try
-      val c = Class.forName("org.fusesource.jansi.AnsiConsole", true, loader)
+      val c =
+        Class.forName(Seq("org", "fusesource", "jansi", "AnsiConsole").mkString("."), true, loader)
       c.getMethod(methodName).invoke(null)
       ()
     catch

--- a/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Launch.scala
@@ -221,7 +221,7 @@ class Launch private[xsbt] (
   @deprecated("sbt handles jansi management itself", "1.1.6")
   def jansiLoader(parent: ClassLoader): ClassLoader =
     val id = AppID(
-      "org.fusesource.jansi",
+      Seq("org", "fusesource", "jansi").mkString("."),
       "jansi",
       JAnsiVersion,
       "",
@@ -234,7 +234,12 @@ class Launch private[xsbt] (
     def makeLoader(): ClassLoader =
       val urls = toURLs(wrapNull(jansiHome.listFiles(JarFilter)))
       val loader = new URLClassLoader(urls, bootLoader)
-      checkLoader(loader, module, "org.fusesource.jansi.internal.WindowsSupport" :: Nil, loader)
+      checkLoader(
+        loader,
+        module,
+        Seq("org", "fusesource", "jansi", "internal", "WindowsSupport").mkString(".") :: Nil,
+        loader
+      )
     val existingLoader =
       if jansiHome.exists then
         try Some(makeLoader())


### PR DESCRIPTION
…ing it in the bytecode verbatim

- If the `"org.fusesource.jansi"` string exists as-is in the produced bytecode, it gets unconditionally rewritten to `"xsbt.boot.internal.shaded.org.fusesource.jansi"`. This causes issues with resolving the corresponding Maven artifact, as well as loading classes at runtime.
- I've manually tested that this restores the ability to run sbt 0.13 on Windows.

This fixes https://github.com/sbt/sbt/issues/8392.

I'm opening this as a draft PR, because I'm hoping there's a more elegant solution than this. It feels like something is misconfigured in the shading rules.