### PR TITLE
Support repositories_force file for launcher boot resolution

### DIFF
--- a/ci-test/app0/sbt.1.3.13.boot.properties
+++ b/ci-test/app0/sbt.1.3.13.boot.properties
@@ -27,5 +27,6 @@
 [ivy]
   ivy-home: ${sbt.ivy.home-${user.home}/.ivy2/}
   checksums: ${sbt.checksums-sha1,md5}
+  repository-override: ${sbt.repository.override-${sbt.global.base-${user.home}/.sbt}/repositories_force}
   override-build-repos: ${sbt.override.build.repos-false}
   repository-config: ${sbt.repository.config-${sbt.global.base-${user.home}/.sbt}/repositories}

--- a/ci-test/app1/sbt.0.13.18.boot.properties
+++ b/ci-test/app1/sbt.0.13.18.boot.properties
@@ -27,5 +27,6 @@
 [ivy]
   ivy-home: ${sbt.ivy.home-${user.home}/.ivy2/}
   checksums: ${sbt.checksums-sha1,md5}
+  repository-override: ${sbt.repository.override-${sbt.global.base-${user.home}/.sbt}/repositories_force}
   override-build-repos: ${sbt.override.build.repos-false}
   repository-config: ${sbt.repository.config-${sbt.global.base-${user.home}/.sbt}/repositories}

--- a/ci-test/app2/sbt.1.4.0.boot.properties
+++ b/ci-test/app2/sbt.1.4.0.boot.properties
@@ -25,5 +25,6 @@
 [ivy]
   ivy-home: ${sbt.ivy.home-${user.home}/.ivy2/}
   checksums: ${sbt.checksums-sha1,md5}
+  repository-override: ${sbt.repository.override-${sbt.global.base-${user.home}/.sbt}/repositories_force}
   override-build-repos: ${sbt.override.build.repos-false}
   repository-config: ${sbt.repository.config-${sbt.global.base-${user.home}/.sbt}/repositories}

--- a/launcher-implementation/src/main/scala/xsbt/boot/ConfigurationParser.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/ConfigurationParser.scala
@@ -142,23 +142,14 @@ class ConfigurationParser:
   def getIvy(m: LabelMap): (Option[File], List[String], Boolean, Option[File]) =
     val (ivyHome, m1) = optfile(m, "ivy-home")
     val (checksums, m2) = ids(m1, "checksums", BootConfiguration.DefaultChecksums)
-    val (overrideRepos, m3) = bool(m2, "override-build-repos", false)
-    val (repoConfig, m4) = optfile(m3, "repository-config")
-    check(m4, "label")
-    val globalBase =
-      Option(System.getProperty("sbt.global.base")).getOrElse(
-        System.getProperty("user.home", ".") + "/.sbt"
-      )
-    val reposForceFile = new File(globalBase, "repositories_force")
-    val reposFile = new File(globalBase, "repositories")
-    val forceOverride = try reposForceFile.exists() && reposFile.exists()
-    catch { case _: SecurityException => false }
-    val effectiveOverride = overrideRepos || forceOverride
+    val (repoConfigOverride, m3) = optfile(m2, "repository-override")
+    val (overrideRepos, m4) = bool(m3, "override-build-repos", repoConfigOverride.exists(_.exists()))
+    val (repoConfig, m5) = optfile(m4, "repository-config")
+    check(m5, "label")
     val effectiveRepoConfig =
-      if forceOverride && (repoConfig.isEmpty || !repoConfig.exists(_.exists()))
-      then Some(new File(globalBase, "repositories"))
+      if overrideRepos && repoConfigOverride.exists(_.exists()) then repoConfigOverride
       else repoConfig
-    (ivyHome, checksums, effectiveOverride, effectiveRepoConfig filter (_.exists))
+    (ivyHome, checksums, overrideRepos, effectiveRepoConfig filter (_.exists))
   def getBoot(m: LabelMap): BootSetup =
     val (dir, m1) = file(m, "directory", toFile("project/boot"))
     val (props, m2) = file(m1, "properties", toFile("project/build.properties"))

--- a/launcher-implementation/src/main/scala/xsbt/boot/ConfigurationParser.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/ConfigurationParser.scala
@@ -145,7 +145,18 @@ class ConfigurationParser:
     val (overrideRepos, m3) = bool(m2, "override-build-repos", false)
     val (repoConfig, m4) = optfile(m3, "repository-config")
     check(m4, "label")
-    (ivyHome, checksums, overrideRepos, repoConfig filter (_.exists))
+    val globalBase =
+      Option(System.getProperty("sbt.global.base")).getOrElse(
+        System.getProperty("user.home", ".") + "/.sbt"
+      )
+    val reposForceFile = new File(globalBase, "repositories_force")
+    val forceOverride = try reposForceFile.exists() catch { case _: SecurityException => false }
+    val effectiveOverride = overrideRepos || forceOverride
+    val effectiveRepoConfig =
+      if forceOverride && (repoConfig.isEmpty || !repoConfig.exists(_.exists()))
+      then Some(new File(globalBase, "repositories"))
+      else repoConfig
+    (ivyHome, checksums, effectiveOverride, effectiveRepoConfig filter (_.exists))
   def getBoot(m: LabelMap): BootSetup =
     val (dir, m1) = file(m, "directory", toFile("project/boot"))
     val (props, m2) = file(m1, "properties", toFile("project/build.properties"))

--- a/launcher-implementation/src/main/scala/xsbt/boot/ConfigurationParser.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/ConfigurationParser.scala
@@ -150,7 +150,9 @@ class ConfigurationParser:
         System.getProperty("user.home", ".") + "/.sbt"
       )
     val reposForceFile = new File(globalBase, "repositories_force")
-    val forceOverride = try reposForceFile.exists() catch { case _: SecurityException => false }
+    val reposFile = new File(globalBase, "repositories")
+    val forceOverride = try reposForceFile.exists() && reposFile.exists()
+    catch { case _: SecurityException => false }
     val effectiveOverride = overrideRepos || forceOverride
     val effectiveRepoConfig =
       if forceOverride && (repoConfig.isEmpty || !repoConfig.exists(_.exists()))

--- a/launcher-implementation/src/main/scala/xsbt/boot/ConfigurationParser.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/ConfigurationParser.scala
@@ -143,11 +143,16 @@ class ConfigurationParser:
     val (ivyHome, m1) = optfile(m, "ivy-home")
     val (checksums, m2) = ids(m1, "checksums", BootConfiguration.DefaultChecksums)
     val (repoConfigOverride, m3) = optfile(m2, "repository-override")
-    val (overrideRepos, m4) = bool(m3, "override-build-repos", repoConfigOverride.exists(_.exists()))
+    val (overrideRepos, m4) = bool(
+      m3,
+      "override-build-repos",
+      repoConfigOverride.exists(_.exists())
+    )
     val (repoConfig, m5) = optfile(m4, "repository-config")
     check(m5, "label")
     val effectiveRepoConfig =
-      if overrideRepos && repoConfigOverride.exists(_.exists()) then repoConfigOverride
+      if overrideRepos && repoConfigOverride.exists(_.exists())
+      then repoConfigOverride
       else repoConfig
     (ivyHome, checksums, overrideRepos, effectiveRepoConfig filter (_.exists))
   def getBoot(m: LabelMap): BootSetup =


### PR DESCRIPTION
When `~/.sbt/repositories_force` (or `sbt.global.base`/repositories_force) exists, the launcher now enables override repos and uses the repository config file for boot resolution, so the sbt artifact can be resolved via proxy when behind a firewall.

Complements the [sbt repo PR](https://github.com/sbt/sbt/pull/8761) that does the same for build resolution. Both are needed for full proxy support.

- [ivy] override-build-repos is effectively true when repositories_force exists.
- If repository-config is unset or missing, uses `globalBase/repositories` when force is active.