### PR TITLE
feat: Suppress sys.exit when -Dsbt.boot.exit=false

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/Boot.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Boot.scala
@@ -13,14 +13,20 @@ object Boot:
   lazy val globalBase = sys.props.get("sbt.global.base").getOrElse(defaultGlobalBase.toString)
 
   def main(args: Array[String]): Unit =
-    standBy()
-    val config = parseArgs(args)
-    // If we havne't exited, we set up some hooks and launch
-    System.clearProperty("scala.home") // avoid errors from mixing Scala versions in the same JVM
-    System.setProperty("jline.shutdownhook", "false") // shutdown hooks cause class loader leaks
-    System.setProperty("jline.esc.timeout", "0") // starts up a thread otherwise
-    CheckProxy()
-    run(config)
+    try
+      standBy()
+      val config = parseArgs(args)
+      // If we haven't exited, we set up some hooks and launch
+      System.clearProperty("scala.home") // avoid errors from mixing Scala versions in the same JVM
+      System.setProperty("jline.shutdownhook", "false") // shutdown hooks cause class loader leaks
+      System.setProperty("jline.esc.timeout", "0") // starts up a thread otherwise
+      CheckProxy()
+      run(config)
+    catch
+      // When sbt.boot.exit=false is set by an embedding application, exit() converts
+      // sys.exit calls into this exception so the host JVM is not terminated.
+      // See: https://github.com/sbt/sbt/issues/7540
+      case _: BootExit => ()
 
   def standBy(): Unit =
     import scala.concurrent.duration.Duration
@@ -45,7 +51,7 @@ object Boot:
       args match
         case "--launcher-version" :: _ =>
           Console.err.println(
-            "sbt launcher version " + Package.getPackage("xsbt.boot").getImplementationVersion
+            "sbt launcher version " + getClass.getPackage.getImplementationVersion
           )
           exit(0)
         case "--rt-ext-dir" :: _ =>
@@ -85,5 +91,15 @@ object Boot:
     }
     exit(1)
 
-  private def exit(code: Int): Nothing =
-    sys.exit(code)
+  // Public so Find.scala can route its own System.exit calls through here.
+  def exit(code: Int): Nothing =
+    if exitSuppressed then throw BootExit(code)
+    else sys.exit(code)
+
+  // When an embedding application sets -Dsbt.boot.exit=false, exit() throws
+  // BootExit instead of calling sys.exit, so Boot.main can catch it and return
+  // normally without terminating the host JVM.
+  private def exitSuppressed: Boolean =
+    sys.props.get("sbt.boot.exit").exists(_.toLowerCase == "false")
+
+  private case class BootExit(code: Int) extends RuntimeException(code.toString)

--- a/launcher-implementation/src/main/scala/xsbt/boot/Find.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Find.scala
@@ -35,7 +35,7 @@ class Find(config: LaunchConfiguration):
                   "[error] [launcher] search method is 'only' and multiple ancestor directories match:\n\t" + fromRoot
                     .mkString("\n\t")
                 )
-                System.exit(1)
+                Boot.exit(1)
                 None
         case _ => Some(current)
     val baseDirectory = orElse(found, current)

--- a/launcher-implementation/src/test/scala/xsbt/boot/BootExitSuppressionTest.scala
+++ b/launcher-implementation/src/test/scala/xsbt/boot/BootExitSuppressionTest.scala
@@ -1,0 +1,34 @@
+/*
+ * sbt
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package xsbt.boot
+
+object BootExitSuppressionTest extends verify.BasicTestSuite:
+  private def withExitSuppressed[T](body: => T): T =
+    val key = "sbt.boot.exit"
+    val prev = sys.props.get(key)
+    System.setProperty(key, "false")
+    try body
+    finally
+      prev match
+        case None    => System.clearProperty(key)
+        case Some(v) => System.setProperty(key, v)
+
+  test("Boot.main does not terminate the JVM for --launcher-version when suppressed") {
+    withExitSuppressed {
+      Boot.main(Array("--launcher-version"))
+      // If sys.exit was called, the test JVM would be terminated.
+    }
+  }
+
+  test("Boot.main does not terminate the JVM on error path when suppressed") {
+    withExitSuppressed {
+      // This argument triggers an error path in the launcher (missing/invalid launch configuration).
+      // We mainly care that it does not hard-exit the embedding JVM.
+      Boot.main(Array("--bad-flag-that-will-error"))
+      // If sys.exit was called, the test JVM would be terminated.
+    }
+  }
+

--- a/launcher-implementation/src/test/scala/xsbt/boot/BootExitSuppressionTest.scala
+++ b/launcher-implementation/src/test/scala/xsbt/boot/BootExitSuppressionTest.scala
@@ -31,4 +31,3 @@ object BootExitSuppressionTest extends verify.BasicTestSuite:
       // If sys.exit was called, the test JVM would be terminated.
     }
   }
-


### PR DESCRIPTION
## Problem
Programmatic (embedded) callers that invoke `xsbt.boot.Boot.main(args)` can have their host JVM terminated because the launcher internally calls `sys.exit(code)`.  
This breaks the requirement of safely *“calling the launcher without killing the embedding process”* ([sbt/sbt#7540](https://github.com/sbt/sbt/issues/7540)).

## Solution
- **Suppress JVM exit when requested**  
  Updated `xsbt.boot.Boot` so that when `-Dsbt.boot.exit=false` is set:
  - `exit(code)` no longer calls `sys.exit(code)`  
  - Instead, it throws an internal exception (`BootExit`) which `Boot.main` catches, allowing the method to return normally.

- **Handle edge cases in `xsbt.boot.Find`**  
  Routed the remaining direct `System.exit(1)` call through `Boot.exit(1)` so it also respects `-Dsbt.boot.exit=false`.

- **Add test coverage**  
  Introduced `xsbt.boot.BootExitSuppressionTest` to verify that `Boot.main` does **not** terminate the JVM in both scenarios:
  - Normal arguments (e.g., `--launcher-version`)  
  - Error paths when suppression is enabled


**Generated-by Claude Sonnet 4.5**

Closes [#7540](https://github.com/sbt/sbt/issues/7540)

 I've signed CLA 

## Tests
```bash
sbt -batch "launchSub/testOnly xsbt.boot.BootExitSuppressionTest"
