### PR TITLE
[1.x] fix: Prevent standBy() from running twice on launcher reload

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/Boot.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/Boot.scala
@@ -33,6 +33,7 @@ object Boot:
     val x = System.getProperty("sbt.launcher.standby")
     if x == null then ()
     else
+      System.clearProperty("sbt.launcher.standby") // prevent double-execution on FullReload
       val sec = Duration(x).toSeconds
       if sec >= 1 then
         (sec to 1 by -1) foreach { i =>


### PR DESCRIPTION
**Problem**
Passing -J-Dsbt.launcher.standby=5s causes the launcher to wait 10s instead of 5s. standBy() is called on each Boot.main() entry and the system property persists across a FullReload cycle, causing a second full countdown.

**Solution**
Clear the sbt.launcher.standby system property immediately after the first read. Subsequent standBy() calls read null and return immediately.

**_Closes sbt/sbt#9107_**