### PR TITLE
Combine repository override configuration with file existence

### DIFF
--- a/launcher-implementation/src/main/scala/xsbt/boot/ConfigurationParser.scala
+++ b/launcher-implementation/src/main/scala/xsbt/boot/ConfigurationParser.scala
@@ -143,17 +143,13 @@ class ConfigurationParser:
     val (ivyHome, m1) = optfile(m, "ivy-home")
     val (checksums, m2) = ids(m1, "checksums", BootConfiguration.DefaultChecksums)
     val (repoConfigOverride, m3) = optfile(m2, "repository-override")
-    val (overrideRepos, m4) = bool(
-      m3,
-      "override-build-repos",
-      repoConfigOverride.exists(_.exists())
-    )
+    val repoConfigOverrideExists = repoConfigOverride.exists(_.exists())
+    val (configuredOverrideRepos, m4) = bool(m3, "override-build-repos", false)
+    val overrideRepos = configuredOverrideRepos || repoConfigOverrideExists
     val (repoConfig, m5) = optfile(m4, "repository-config")
     check(m5, "label")
     val effectiveRepoConfig =
-      if overrideRepos && repoConfigOverride.exists(_.exists())
-      then repoConfigOverride
-      else repoConfig
+      if repoConfigOverrideExists then repoConfigOverride else repoConfig
     (ivyHome, checksums, overrideRepos, effectiveRepoConfig filter (_.exists))
   def getBoot(m: LabelMap): BootSetup =
     val (dir, m1) = file(m, "directory", toFile("project/boot"))

--- a/launcher-implementation/src/test/scala/ConfigurationParserTest.scala
+++ b/launcher-implementation/src/test/scala/ConfigurationParserTest.scala
@@ -5,9 +5,51 @@
 
 package xsbt.boot
 
+import java.io.File
 import java.net.URI
+import java.nio.file.Files
 
 object ConfigurationParserTest extends verify.BasicTestSuite:
+  test("repository override activation combines the configured value and file existence") {
+    val directory = Files.createTempDirectory("launcher-repository-override-test").toFile
+    val repositoryConfig = new File(directory, "repositories")
+    val repositoryOverride = new File(directory, "repositories_force")
+    Files.write(repositoryConfig.toPath, "[repositories]\n  local\n".getBytes("UTF-8"))
+
+    try
+      val cases = List(
+        (false, false, false, repositoryConfig),
+        (true, false, true, repositoryConfig),
+        (false, true, true, repositoryOverride),
+        (true, true, true, repositoryOverride)
+      )
+
+      cases.foreach {
+        case (configuredOverride, overrideFileExists, expectedOverride, expectedFile) =>
+          if overrideFileExists then
+            Files.write(
+              repositoryOverride.toPath,
+              "[repositories]\n  maven-central\n".getBytes("UTF-8")
+            )
+          else Files.deleteIfExists(repositoryOverride.toPath)
+
+          val ivy =
+            ListMap[String, Option[String]](
+              "override-build-repos" -> Option(configuredOverride.toString),
+              "repository-config" -> Option(repositoryConfig.getAbsolutePath),
+              "repository-override" -> Option(repositoryOverride.getAbsolutePath)
+            ).default(_ => None)
+          val (_, _, actualOverride, actualFile) = (new ConfigurationParser).getIvy(ivy)
+
+          assert(actualOverride == expectedOverride)
+          assert(actualFile.contains(expectedFile))
+      }
+    finally
+      Files.deleteIfExists(repositoryOverride.toPath)
+      Files.deleteIfExists(repositoryConfig.toPath)
+      Files.deleteIfExists(directory.toPath)
+  }
+
   test("Configuration parser should correct parse bootOnly") {
     repoFileContains(
       """|[repositories]


### PR DESCRIPTION
First step to solving https://github.com/sbt/sbt/issues/9369. Second part of the fix is https://github.com/sbt/sbt/pull/9452.

Prior work that changed the JVM flag processing semantics, thereby causing the issue: https://github.com/sbt/sbt/pull/8761

The processing pipeline involved in the issue:

1. sbt-launcher - configures the launcher to launch sbt. Propagates user-supplied configuration to the launcher:
    - config field`override-build-repos`: JVM flag `sbt.override.build.repos=true`
    - config field `repository-override`: File `repositories_force`
2. launcher - consumes sbt-launcher-supplied config. Outputs `isOverrideRepositories` boolean flag based on the data supplied by (1) sbt-launcher.
3. Project-specific sbt runtime. Launcher by the launcher. Sets a setting whether or not to override repos.
    - sbt 1: sets it to (2) launcher output flag.
    - sbt 2: (2) launcher output flag OR (1) JVM flag `sbt.override.build.repos=true`

The fix is two-fold:

1. Teach launcher that repos are meant to be overridden either on flag or file presence. `isOverrideRepositories = configuredOverrideRepos || repoConfigOverrideExists`.
2. In the sbt-launcher template, restore `override-build-repos` that was removed in https://github.com/sbt/sbt/pull/8761/changes#diff-f12f6468a3b483d79284e248213d4c1897f90ab80159db60343f9d907abf5188L28. This would propagate the JVM flag to the launcher to be used in `isOverrideRepositories` computation.

This PR is the implementation of the part 1 of the fix. Once launcher is released, we can bump the launcher version on sbt/sbt and implement step (2).